### PR TITLE
feat: bump the delete_timeout on ibm_tg_gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_classic_connections_count"></a> [classic\_connections\_count](#input\_classic\_connections\_count) | Number of classic connections to add. | `number` | n/a | yes |
+| <a name="input_delete_timeout"></a> [delete\_timeout](#input\_delete\_timeout) | Deleting timeout value of the ibm\_tg\_gateway | `string` | `"45m"` | no |
 | <a name="input_existing_transit_gateway_name"></a> [existing\_transit\_gateway\_name](#input\_existing\_transit\_gateway\_name) | Name of an existing transit gateway to connect VPCs. If null a new Transit Gateway will be created (transit\_gateway\_name and region required) | `string` | `null` | no |
 | <a name="input_global_routing"></a> [global\_routing](#input\_global\_routing) | Gateways with global routing (true) to connect to the networks outside their associated region | `bool` | `false` | no |
 | <a name="input_region"></a> [region](#input\_region) | The IBM Cloud region where all resources are provisioned. It can be null if existing\_transit\_gateway\_name is not null | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,9 @@ resource "ibm_tg_gateway" "tg_gw_instance" {
   global         = var.global_routing != null ? var.global_routing : false
   resource_group = var.resource_group_id != null ? var.resource_group_id : null
   tags           = var.resource_tags != null ? var.resource_tags : null
+  timeouts {
+    delete = var.delete_timeout
+  }
 }
 
 resource "ibm_tg_connection" "vpc_connections" {

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -14,6 +14,16 @@
         "line": 42
       }
     },
+    "delete_timeout": {
+      "name": "delete_timeout",
+      "type": "string",
+      "description": "Deleting timeout value of the ibm_tg_gateway",
+      "default": "45m",
+      "pos": {
+        "filename": "variables.tf",
+        "line": 47
+      }
+    },
     "existing_transit_gateway_name": {
       "name": "existing_transit_gateway_name",
       "type": "string",
@@ -183,7 +193,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 29
+        "line": 32
       }
     },
     "ibm_tg_connection.vpc_connections": {
@@ -199,7 +209,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 20
+        "line": 23
       }
     },
     "ibm_tg_gateway.tg_gw_instance": {

--- a/variables.tf
+++ b/variables.tf
@@ -43,3 +43,9 @@ variable "classic_connections_count" {
   type        = number
   description = "Number of classic connections to add."
 }
+
+variable "delete_timeout" {
+  type        = string
+  description = "Deleting timeout value of the ibm_tg_gateway"
+  default     = "45m"
+}


### PR DESCRIPTION
### Description

Bump delete timeout on ibm_tg_gateway to 45m

issue: https://github.com/terraform-ibm-modules/terraform-ibm-transit-gateway/issues/263###
### Types of changes in this PR

#### Changes that affect the core Terraform module or submodules
- [ ] Bug fix
- [x] New feature
- [ ] Dependency update

#### Changes that don't affect the core Terraform module or submodules
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other

#### Release required?
Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning).

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Bump delete timeout on ibm_tg_gateway to 45m

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
