### PR TITLE
fix: disabled test parallelism to test ratelimiter on APIs

### DIFF
--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -186,7 +186,7 @@ func TestRunBasicExample(t *testing.T) {
 }
 
 func TestRun2VpcsExample(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	options := setupOptions2VpcsExample(t, "twovpcs-tg")
 
@@ -196,7 +196,7 @@ func TestRun2VpcsExample(t *testing.T) {
 }
 
 func TestRunMultipleConnectionsExample(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	options := setupOptionsMultipleConnectionsExample(t, "multiconns-tg")
 
@@ -206,7 +206,7 @@ func TestRunMultipleConnectionsExample(t *testing.T) {
 }
 
 func TestRun2VpcsPrefixFilterExample(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	options := setupOptions2VpcsPrefixFilterExample(t, "prefix-tg")
 
@@ -228,7 +228,7 @@ func TestRun2VpcsPrefixFilterExample(t *testing.T) {
 // }
 
 func TestRunUpgradeExample(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	options := setupOptionsBasicExample(t, "ibm-tgn")
 


### PR DESCRIPTION
### Description

disabled test parallelism to test ratelimiter on APIs

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
